### PR TITLE
feat: support helpers from directories

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -291,6 +291,11 @@ info:
   version: <$ injectPackageJsonVersion() $>
 ```
 
+If the helper is a folder, boats will recursively add all js or ts files as helpers:
+```
+boats -i ./src/index.yml -o ./build/myapi.yml -f ./tplHelpers/
+```
+
 - Custom helpers are injected via the [Nunjuck's addGlobal function](https://mozilla.github.io/nunjucks/api.html#addglobal).
 - A helper function should use the `function` keyword declaration to gain access to the nunjucks context.
 - The name of the helper file will be the name of the function, non-alphanumeric (and _) characters will be stripped.
@@ -682,6 +687,7 @@ url: <$ host $>
 > !Tip: These variables will override any variables injected into the tpl engine from the `process.env`
 
 ## Changelog
+- 2022/05/15 2.34.0: Changed: cli helpers `-f helper` will recursively add helpers from a folder when specified
 - 2021/03/26 2.33.0: Security updates
 - 2021/03/26 2.32.0: Fix: map channels index [issues/70](https://github.com/j-d-carmichael/boats/issues/70)
 - 2021/03/26 2.31.0: Fix: ts-node require once [issues/69](https://github.com/j-d-carmichael/boats/issues/69)

--- a/src/__tests__/Template.spec.ts
+++ b/src/__tests__/Template.spec.ts
@@ -15,6 +15,7 @@ Weather:
 Weathers:
   object: mixin('some/other/path', 654654)
 `;
+
 describe('setMixinPositions', () => {
   it('match simple mixin', () => {
     const response = JSON.stringify(Template.setMixinPositions(string1, 2));
@@ -23,13 +24,13 @@ describe('setMixinPositions', () => {
         {
           index: 33,
           match: "mixin('some/path', 321)",
-          mixinPath: "some/path",
+          mixinPath: 'some/path',
           mixinLinePadding: '  ',
         },
         {
           index: 77,
           match: "mixin('some/pther/path', 654654)",
-          mixinPath: "some/pther/path",
+          mixinPath: 'some/pther/path',
           mixinLinePadding: '  ',
         },
       ])
@@ -43,13 +44,13 @@ describe('setMixinPositions', () => {
         {
           index: 43,
           match: "mixin('some/path', 321)",
-          mixinPath: "some/path",
+          mixinPath: 'some/path',
           mixinLinePadding: '  ',
         },
         {
           index: 97,
           match: "mixin('some/other/path', 654654)",
-          mixinPath: "some/other/path",
+          mixinPath: 'some/other/path',
           mixinLinePadding: '  ',
         },
       ])
@@ -63,6 +64,7 @@ describe('stripNjkExtension', () => {
       '/some/path/helpers/myCoolHelper.js'
     );
   });
+
   it('should return plain', function () {
     expect(Template.stripNjkExtension('/some/path/helpers/myCoolHelper.js')).toBe('/some/path/helpers/myCoolHelper.js');
   });
@@ -112,15 +114,15 @@ describe('nunjucksSetup', () => {
     mockEnv = {
       addGlobal(k: any, v: any) {
         this[k] = v;
-      }
+      },
     };
 
     jest.mock('nunjucks', () => ({
-      configure: () => mockEnv
+      configure: () => mockEnv,
     }));
 
     mockTsNode = {
-      register: jest.fn()
+      register: jest.fn(),
     };
 
     jest.mock('ts-node', () => mockTsNode);
@@ -129,7 +131,7 @@ describe('nunjucksSetup', () => {
     template.inputFile = 'test.yml';
     template.helpFunctionPaths = [];
     template.boatsrc = {
-      nunjucksOptions: { beep: 'boop' }
+      nunjucksOptions: { beep: 'boop' },
     };
   });
 
@@ -154,7 +156,7 @@ describe('nunjucksSetup', () => {
       'indentNumber',
       'indentObject',
       'mixinVarNamePrefix',
-      'currentFilePointer'
+      'currentFilePointer',
     ];
 
     for (const name of internalHelpersNames) {
@@ -174,7 +176,7 @@ describe('nunjucksSetup', () => {
       'mixin',
       'routePermission',
       'uniqueOpId',
-      'packageJson'
+      'packageJson',
     ];
 
     for (const name of importedFnNames) {
@@ -188,22 +190,52 @@ describe('nunjucksSetup', () => {
   });
 
   it('loads external helper from file - javascript', () => {
-    template.helpFunctionPaths = [
-      upath.normalize(`${__dirname}/testHelpers/exampleJsHelper.js`)
-    ];
+    template.helpFunctionPaths = [upath.normalize(`${__dirname}/testHelpers/exampleJsHelper.js`)];
 
     template.nunjucksSetup();
     expect(mockEnv.exampleJsHelper.name).toBe('exampleJsHelper');
   });
 
   it('loads external helper from file - typescript', () => {
-    template.helpFunctionPaths = [
-      upath.normalize(`${__dirname}/testHelpers/exampleTsHelper.ts`)
-    ];
+    template.helpFunctionPaths = [upath.normalize(`${__dirname}/testHelpers/exampleTsHelper.ts`)];
 
     template.nunjucksSetup();
 
     expect(mockTsNode.register).toBeCalled();
     expect(mockEnv.exampleTsHelper.name).toBe('exampleTsHelper');
+  });
+
+  it('loads external helper from file - files and folders', () => {
+    template.helpFunctionPaths = [
+      upath.normalize(`${__dirname}/testHelpers/exampleJsHelper.js`),
+      upath.normalize(`${__dirname}/testHelpers/exampleTsHelper.ts`),
+      upath.normalize(`${__dirname}/testHelpers/moreHelpers`),
+    ];
+
+    expect(Object.keys(mockEnv).length).toBe(1);
+
+    template.nunjucksSetup();
+
+    expect(mockTsNode.register).toBeCalled();
+    expect(mockEnv.exampleJsHelper.name).toBe('exampleJsHelper');
+    expect(mockEnv.exampleTsHelper.name).toBe('exampleTsHelper');
+    expect(mockEnv.justAnotherJsHelper.name).toBe('justAnotherJsHelper');
+    expect(mockEnv.justAnotherTsHelper.name).toBe('justAnotherTsHelper');
+  });
+
+  it('loads external helper from file - recursive', () => {
+    template.helpFunctionPaths = [
+      upath.normalize(`${__dirname}/testHelpers`),
+    ];
+
+    expect(Object.keys(mockEnv).length).toBe(1);
+
+    template.nunjucksSetup();
+
+    expect(mockTsNode.register).toBeCalled();
+    expect(mockEnv.exampleJsHelper.name).toBe('exampleJsHelper');
+    expect(mockEnv.exampleTsHelper.name).toBe('exampleTsHelper');
+    expect(mockEnv.justAnotherJsHelper.name).toBe('justAnotherJsHelper');
+    expect(mockEnv.justAnotherTsHelper.name).toBe('justAnotherTsHelper');
   });
 });

--- a/src/__tests__/testHelpers/moreHelpers/justAnotherJsHelper.js
+++ b/src/__tests__/testHelpers/moreHelpers/justAnotherJsHelper.js
@@ -1,0 +1,1 @@
+module.exports = () => function justAnotherJsHelper() {};

--- a/src/__tests__/testHelpers/moreHelpers/justAnotherTsHelper.ts
+++ b/src/__tests__/testHelpers/moreHelpers/justAnotherTsHelper.ts
@@ -1,0 +1,1 @@
+export default () => function justAnotherTsHelper() {};


### PR DESCRIPTION
Please ensure your pull request:
- [x] Includes additions to the docs, found in the docs/readme file, as required
- [x] Includes a new line in the changelog titling the change 
- [x] The new and changed code you have written is unit tested and passes the eslint
- [x] The body of the text for this PR includes enough text for a reviewer to understand the context of the change

Added support for passing folders to helper param in cli.

When a folder is used, recursively searches for all js/ts helpers and adds them to the tpl env.

```bash
boats -i api.yml -o build/out.yml -f helpers/ -f node_modules/jquery2/underscore.js
```