### PR TITLE
Ignore yaml extension

### DIFF
--- a/src/removeFileExtension.ts
+++ b/src/removeFileExtension.ts
@@ -3,5 +3,6 @@ import stripFromEndOfString from '@/stripFromEndOfString';
 export default (filePath: string): string => {
   filePath = stripFromEndOfString(filePath, '.njk');
   filePath = stripFromEndOfString(filePath, '.yml');
+  filePath = stripFromEndOfString(filePath, '.yaml');
   return filePath;
 };


### PR DESCRIPTION
Hi ! 

I using this project to generate some openapi specs and I was experencing some troubles with Schema Name Generation.

For example :

PaginationPage.yaml
```yaml
name: page
in: query
schema:
  type: integer
  minimum: 1
```

Will generate :

```yaml
PaginationPageYaml:
  name: page
  in: query
  schema:
    type: integer
    minimum: 1
```

And I expected :

```yaml
PaginationPage:
  name: page
  in: query
  schema:
    type: integer
    minimum: 1
```

I found in the codebase that .yaml files extension was not stripped when Auto Index generate schema names.

This PR add yaml in the extension remover list.